### PR TITLE
Change tsconfig to emit type declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,5 +15,6 @@
   "devDependencies": {
     "@types/node": "^16.11.9",
     "typedoc": "^0.22.9"
-  }
+  },
+  "types": "node/dist/index.d.ts"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "declaration": true
   },
   "include": [
     "node/lib/*.ts"


### PR DESCRIPTION
This makes it possible for TypeScript users to use this library with its types.

This compiler setting causes the build operation to create `.d.ts` files which give type information about the module.